### PR TITLE
Fix missing VersionId param in s3.getObject

### DIFF
--- a/src/compareS3.js
+++ b/src/compareS3.js
@@ -14,8 +14,8 @@ const compareS3 = async (oldVersion, newVersion) => {
     console.log ({oldVersion, newVersion})
 
     // Get original text from objects 
-    const oldObject = await s3.getObject({ Bucket: oldVersion.BucketName, Key: oldVersion.Key }).promise()
-    const newObject = await s3.getObject({ Bucket: newVersion.BucketName, Key: newVersion.Key }).promise()
+    const oldObject = await s3.getObject({ Bucket: oldVersion.BucketName, Key: oldVersion.Key, VersionId: oldVersion.VersionId }).promise()
+    const newObject = await s3.getObject({ Bucket: newVersion.BucketName, Key: newVersion.Key, VersionId: newVersion.VersionId }).promise()
 
     // Convert buffers to strings
     const oldFile = oldObject.Body.toString()


### PR DESCRIPTION
Fixes bug where oldObject was equals newObject equals latest version of the object as VersionId param was missing in s3.getObject

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
